### PR TITLE
Show existing sgf file when saving sgf file

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -349,7 +349,7 @@ public abstract class MainFrame extends JFrame {
   }
 
   public void saveFile() {
-    FileNameExtensionFilter filter = new FileNameExtensionFilter("*.sgf", "*.SGF");
+    FileNameExtensionFilter filter = new FileNameExtensionFilter("sgf file", "sgf", "SGF");
     JSONObject filesystem = Lizzie.config.persisted.getJSONObject("filesystem");
     JFileChooser chooser = new JFileChooser(filesystem.getString("last-folder"));
     chooser.setFileFilter(filter);


### PR DESCRIPTION
When saving as an sgf file, it was not displayed even if multiple sgf files existed in the specified folder. This simple fix will make it visible.