### PR TITLE
Display engines list by nickname first.

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -1052,7 +1052,7 @@ public class Leelaz {
   }
 
   public String nicknameOrcurrentWeight() {
-    return (engineNickname == null) ? currentWeight : engineNickname;
+    return (currentWeight == null) ? engineNickname : currentWeight;
   }
 
   public String currentWeight() {


### PR DESCRIPTION
Currently engine name displayed empty when weight file is missing(eg. leela 0.11.0, katago-colab) even though nickname is defined.
So change display priority to nickname first and then weight file name displayed when there's no nickname defined.